### PR TITLE
Fix channel authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Project exclude paths
+/.idea/
+/node_modules/
+/watched_channels.json
+/package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meme_enforcer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "bot.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
It is now checked whether the channel that is about to be added and the command are on the same guild, if not the "Undefined channel" error will pop up and the channel will not be added. Otherwise a user could edit the config from another server from their own where they are admin. This is fixed now.

Also the presence will indicate how many channels are currently on the watchlist as well as the version number of the bot.