### PR TITLE
Fix refresh activity status

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -26,6 +26,10 @@ client.on('messageCreate', message => {
 client.on('ready', () => {
    console.log('Connected!');
    updateActivity();
+   // Set activity status once, then every hour
+   setInterval(function() {
+       updateActivity();
+   }, 3600000)
 });
 
 function handleMessage(message) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meme_enforcer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "bot.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Sometimes the bot lost its activity status (indicating amount of watched channels), so now it will update at least every hour (and dynamically when the channel config changes)