### PR TITLE
Hotfix/channel pase&modcheck

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -158,11 +158,17 @@ function parseChannelId(string, message) {
     }
     if(string.startsWith('<#') && string.endsWith('>')) {
         string = string.slice(2, -1);
-        let channelId = client.channels.cache.get(string).id;
-        let guildId = client.channels.cache.get(string).guildId;
-        if(message.guildId === guildId) {
-            return channelId;
-        }
+    }
+    let channelId, guildId;
+    try {
+        channelId = client.channels.cache.get(string).id;
+        guildId = client.channels.cache.get(string).guildId;
+    }catch (error) {
+        console.error("Unknown channel / guild: ", error);
+        return;
+    }
+    if(typeof channelId !== 'undefined' && message.guildId === guildId) {
+        return channelId;
     }
 }
 

--- a/bot.js
+++ b/bot.js
@@ -111,7 +111,7 @@ function isMod(message) {
     if(message.inGuild()) {
         let mod = false;
         try {
-            mod = message.member.permissions.has([Permissions.FLAGS.MANAGE_MESSAGES, true]);
+            mod = message.member.permissions.has(Permissions.FLAGS.MANAGE_MESSAGES, true);
         } catch {}
         return mod;
     }else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meme_enforcer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "bot.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Fix a crash when an invalid channel id was used in the watch/unwatch command
- fix checking for manage messages permission (modcheck)
- bump version to 1.1.1